### PR TITLE
Modified beta.openbadges issuer to backpack.openbadges

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -133,7 +133,7 @@
           </footer>
         </div>
         <script src="/jquery.min.js"></script>
-        <script src="https://beta.openbadges.org/issuer.js"></script>
+        <script src="https://backpack.openbadges.org/issuer.js"></script>
         <script src="/common.js"></script>
         <script src="/badges.js"></script>
         <script type="text/javascript" src="/fancybox/source/jquery.fancybox.pack.js?v=2.1.5"></script>


### PR DESCRIPTION
Hi Whitmer, 

I did just a tiny modification to use the "backpack.openbadges.org" issuer and no longer the "beta" version. 
It's the address that you can now see in the issuer API of backpack: (in the "using the API part")
https://github.com/mozilla/openbadges/wiki/Issuer-API

I hope it'll help! 

Kulgar. 
